### PR TITLE
chore: update Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,20 @@
 module github.com/jadolg/clipu
 
-go 1.26
+go 1.26.2
 
-requ
+require (
+	github.com/schollz/peerdiscovery v1.7.6
+	github.com/sirupsen/logrus v1.9.3
+	golang.design/x/clipboard v0.7.1
+)
+
+require (
+	filippo.io/age v1.3.1 // indirect
+	filippo.io/hpke v0.4.0 // indirect
+	golang.org/x/crypto v0.46.0 // indirect
+	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
+	golang.org/x/image v0.28.0 // indirect
+	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
+	golang.org/x/net v0.48.0 // indirect
+	golang.org/x/sys v0.39.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,5 @@
 module github.com/jadolg/clipu
 
-go 1.25
+go 1.26
 
-require (
-	github.com/schollz/peerdiscovery v1.7.6
-	github.com/sirupsen/logrus v1.9.3
-	golang.design/x/clipboard v0.7.1
-)
-
-require (
-	filippo.io/age v1.3.1 // indirect
-	filippo.io/hpke v0.4.0 // indirect
-	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
-	golang.org/x/image v0.28.0 // indirect
-	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
-	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
-)
+requ


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.2**.

### Changes
- go.mod: go 1.25 → go 1.26.2

_Automated PR by update-go-version.sh_